### PR TITLE
Restricted file access by attaching lsm/open

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,21 +16,24 @@ $(BPF_BUILDDIR)/%.bpf.o: pkg/bpf/c/%.bpf.c $(wildcard bpf/*.h) | $(BPF_BUILDDIR)
 .PHONY: bpf-restricted-network
 bpf-restricted-network: $(BPF_BUILDDIR)/restricted-network.bpf.o
 
+.PHONY: bpf-restricted-file
+bpf-restricted-file: $(BPF_BUILDDIR)/restricted-file.bpf.o
+
 .PHONY: vmlinux
 vmlinux:
 	$(shell bpftool btf dump file /sys/kernel/btf/vmlinux format c > vmlinux.h)
 
 .PHONY: build
-build: bpf-restricted-network
+build: bpf-restricted-network bpf-restricted-file
 	$(CGOFLAG) go build -ldflags '-w -s' -o bouheki cmd/bouheki/bouheki.go
 
 .PHONY: test
-test: bpf-restricted-network
+test: bpf-restricted-network bpf-restricted-file
 	which gotestsum || go install gotest.tools/gotestsum@latest
 	CGO_LDFLAGS="-lbpf" sudo -E gotestsum -- --mod=vendor -bench=^$$ -race ./...
 
 .PHONY: test/integration
-test/integration: bpf-restricted-network
+test/integration: bpf-restricted-network bpf-restricted-file
 	which gotestsum || go install gotest.tools/gotestsum@latest
 	CGO_LDFLAGS="-lbpf" sudo -E gotestsum -- --tags=integration --mod=vendor -bench=^$$ -race ./...
 

--- a/pkg/bpf/c/common.h
+++ b/pkg/bpf/c/common.h
@@ -184,3 +184,32 @@ static inline int is_container()
 {
   return !_is_host_mntns();
 }
+
+static inline int strcmp(const unsigned char *a, const unsigned char *b, size_t len)
+{
+  unsigned char c1, c2;
+  size_t i;
+
+  for (i=0; i<len; i++) {
+    c1 = (unsigned char)a[i];
+    c2 = (unsigned char)b[i];
+
+    if (c1 != c2 || c1 == '\0' || c2 == '\0') {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+static __always_inline int strlen(const unsigned char *s, size_t max_len)
+{
+	size_t i;
+
+	for (i = 0; i < max_len; i++) {
+		if (s[i] == '\0')
+			return i;
+	}
+
+	return i;
+}

--- a/pkg/bpf/c/restricted-file.bpf.c
+++ b/pkg/bpf/c/restricted-file.bpf.c
@@ -9,6 +9,7 @@ char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
 #define FILE_NAME_LEN	32
 #define PATH_LEN 256
+#define NAME_MAX 255
 
 struct file_path {
     unsigned char path[PATH_LEN];
@@ -19,13 +20,23 @@ struct callback_ctx {
     bool found;
 };
 
+struct file_open_audit_event {
+    unsigned char path[NAME_MAX];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(u32));
+	__uint(value_size, sizeof(u32));
+} fileopen_events SEC(".maps");
+
 BPF_HASH(allowed_access_files, u32, struct file_path, 256);
 BPF_HASH(denied_access_files, u32, struct file_path, 256);
 
 static u64 cb_check_path(struct bpf_map *map, u32 *key, struct file_path *map_path, struct callback_ctx *ctx) {
     bpf_printk("checking ctx->found: %d, path: map_path: %s, ctx_path: %s", ctx->found, map_path->path, ctx->path);
 
-    size_t size = strlen(map_path->path, PATH_LEN);
+    size_t size = strlen(map_path->path, NAME_MAX);
     if (strcmp(map_path->path, ctx->path, size) == 0) {
         ctx->found = 1;
     }
@@ -43,16 +54,16 @@ int BPF_PROG(restricted_file_open, struct file *file)
     struct file *fp;
     struct dentry *dentry;
     const __u8 *filename;
-    unsigned char full_path[PATH_LEN] = {};
+    struct file_open_audit_event event = {};
     int ret = -1;
 
-    if (bpf_d_path(&file->f_path, full_path, PATH_LEN) < 0) {
+    if (bpf_d_path(&file->f_path, event.path, NAME_MAX) < 0) {
         return 0;
     }
 
     // bpf_printk("%s open %s\n", task, full_path);
 
-    struct callback_ctx cb = { .path = full_path, .found = false};
+    struct callback_ctx cb = { .path = event.path, .found = false};
     cb.found = false;
     bpf_for_each_map_elem(&denied_access_files, cb_check_path, &cb, 0);
     if (cb.found) {
@@ -68,5 +79,6 @@ int BPF_PROG(restricted_file_open, struct file *file)
     }
 
 out:
+    bpf_perf_event_output((void *)ctx, &fileopen_events, BPF_F_CURRENT_CPU, &event, sizeof(event));
     return ret;
 }

--- a/pkg/bpf/c/restricted-file.bpf.c
+++ b/pkg/bpf/c/restricted-file.bpf.c
@@ -1,0 +1,72 @@
+#include "common.h"
+#include "vmlinux.h"
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <linux/errno.h>
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+#define FILE_NAME_LEN	32
+#define PATH_LEN 256
+
+struct file_path {
+    unsigned char path[PATH_LEN];
+};
+
+struct callback_ctx {
+    unsigned char *path;
+    bool found;
+};
+
+BPF_HASH(allowed_access_files, u32, struct file_path, 256);
+BPF_HASH(denied_access_files, u32, struct file_path, 256);
+
+static u64 cb_check_path(struct bpf_map *map, u32 *key, struct file_path *map_path, struct callback_ctx *ctx) {
+    bpf_printk("checking ctx->found: %d, path: map_path: %s, ctx_path: %s", ctx->found, map_path->path, ctx->path);
+
+    size_t size = strlen(map_path->path, PATH_LEN);
+    if (strcmp(map_path->path, ctx->path, size) == 0) {
+        ctx->found = 1;
+    }
+
+    return 0;
+}
+
+SEC("lsm/file_open")
+int BPF_PROG(restricted_file_open, struct file *file)
+{
+    char task[TASK_COMM_LEN];
+
+    bpf_get_current_comm(&task, sizeof(task));
+
+    struct file *fp;
+    struct dentry *dentry;
+    const __u8 *filename;
+    unsigned char full_path[PATH_LEN] = {};
+    int ret = -1;
+
+    if (bpf_d_path(&file->f_path, full_path, PATH_LEN) < 0) {
+        return 0;
+    }
+
+    // bpf_printk("%s open %s\n", task, full_path);
+
+    struct callback_ctx cb = { .path = full_path, .found = false};
+    cb.found = false;
+    bpf_for_each_map_elem(&denied_access_files, cb_check_path, &cb, 0);
+    if (cb.found) {
+        bpf_printk("Access Denied: %s\n", cb.path);
+        ret = -EPERM;
+        goto out;
+    }
+
+    bpf_for_each_map_elem(&allowed_access_files, cb_check_path, &cb, 0);
+    if (cb.found) {
+        ret = 0;
+        goto out;
+    }
+
+out:
+    return ret;
+}

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -1,7 +1,13 @@
 package commands
 
 import (
+	"errors"
+	"os"
+	"os/signal"
+
+	"github.com/mrtc0/bouheki/pkg/commands/fileaccess"
 	"github.com/mrtc0/bouheki/pkg/commands/network"
+	"github.com/mrtc0/bouheki/pkg/config"
 	log "github.com/mrtc0/bouheki/pkg/log"
 	"github.com/mrtc0/bouheki/pkg/utils"
 	"github.com/urfave/cli/v2"
@@ -26,7 +32,28 @@ func NewApp(version string) *cli.App {
 
 	app.Flags = flags
 
-	app.Action = network.Run
+	app.Action = func(c *cli.Context) error {
+		path := c.String("config")
+		conf, err := config.NewConfig(path)
+		if err != nil {
+			return nil
+		}
+		if !utils.AmIRootUser() {
+			return errors.New("Must be run as root user")
+		}
+
+		log.SetFormatter(conf.Log.Format)
+		log.SetOutput(conf.Log.Output)
+		log.SetRotation(conf.Log.Output, conf.Log.MaxSize, conf.Log.MaxAge)
+
+		go network.RunAudit(conf)
+		go fileaccess.RunAudit(conf)
+
+		quit := make(chan os.Signal)
+		signal.Notify(quit, os.Interrupt)
+		<-quit
+		return nil
+	}
 
 	err := utils.IsCompatible()
 	if err != nil {

--- a/pkg/commands/fileaccess/audit.go
+++ b/pkg/commands/fileaccess/audit.go
@@ -48,11 +48,24 @@ func RunAudit(conf *config.Config) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	map_denied_files, err := mod.GetMap(DENIED_FILES_MAP_NAME)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	allowed_paths := conf.RestrictedFileAccess.Allow
 
 	for i, path := range allowed_paths {
 		err = map_allowed_files.Update(uint8(i), []byte(path))
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	denied_paths := conf.RestrictedFileAccess.Deny
+
+	for i, path := range denied_paths {
+		err = map_denied_files.Update(uint8(i), []byte(path))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/commands/fileaccess/audit.go
+++ b/pkg/commands/fileaccess/audit.go
@@ -1,0 +1,65 @@
+package fileaccess
+
+import (
+	"C"
+
+	"github.com/aquasecurity/libbpfgo"
+	"github.com/mrtc0/bouheki/pkg/bpf"
+	log "github.com/mrtc0/bouheki/pkg/log"
+)
+import "github.com/mrtc0/bouheki/pkg/config"
+
+const (
+	BPF_OBJECT_NAME        = "restricted-file"
+	BPF_PROGRAM_NAME       = "restricted_file_open"
+	ALLOWED_FILES_MAP_NAME = "allowed_access_files"
+	DENIED_FILES_MAP_NAME  = "denied_access_files"
+)
+
+func setupBPFProgram() (*libbpfgo.Module, error) {
+	bytecode, err := bpf.EmbedFS.ReadFile("bytecode/restricted-file.bpf.o")
+	if err != nil {
+		return nil, err
+	}
+	mod, err := libbpfgo.NewModuleFromBuffer(bytecode, BPF_OBJECT_NAME)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = mod.BPFLoadObject(); err != nil {
+		return nil, err
+	}
+
+	return mod, nil
+}
+
+func RunAudit(conf *config.Config) {
+	mod, err := setupBPFProgram()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	prog, err := mod.GetProgram(BPF_PROGRAM_NAME)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	map_allowed_files, err := mod.GetMap(ALLOWED_FILES_MAP_NAME)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	allowed_paths := conf.RestrictedFileAccess.Allow
+
+	for i, path := range allowed_paths {
+		err = map_allowed_files.Update(uint8(i), []byte(path))
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	_, err = prog.AttachLSM()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/commands/fileaccess/audit.go
+++ b/pkg/commands/fileaccess/audit.go
@@ -28,6 +28,7 @@ const (
 type auditLog struct {
 	CGroupID      uint64
 	PID           uint32
+	Ret           int32
 	Nodename      [NEW_UTS_LEN + 1]byte
 	Command       [TASK_COMM_LEN]byte
 	ParentCommand [TASK_COMM_LEN]byte
@@ -86,7 +87,7 @@ func RunAudit(conf *config.Config) {
 
 func newAuditLog(event auditLog) log.RestrictedFileAccessLog {
 	auditEvent := log.AuditEventLog{
-		Action:     "BLOCK", // TODO
+		Action:     ret2action(event.Ret),
 		Hostname:   nodename2string(event.Nodename),
 		PID:        event.PID,
 		Comm:       comm2string(event.Command),
@@ -110,6 +111,14 @@ func parseEvent(eventBytes []byte) (auditLog, error) {
 	}
 
 	return event, nil
+}
+
+func ret2action(ret int32) string {
+	if ret == 0 {
+		return "ALLOWED"
+	} else {
+		return "BLOCKED"
+	}
 }
 
 func comm2string(commBytes [16]byte) string {

--- a/pkg/commands/fileaccess/audit.go
+++ b/pkg/commands/fileaccess/audit.go
@@ -10,7 +10,6 @@ import (
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 
 	"github.com/mrtc0/bouheki/pkg/config"
 )
@@ -80,11 +79,26 @@ func RunAudit(conf *config.Config) {
 			log.Error(err)
 		}
 
-		fmt.Printf("%#v\n", event)
-		fmt.Printf("%s\n", comm2string(event.Command))
-		fmt.Printf("%s\n", comm2string(event.ParentCommand))
-		fmt.Printf("%s\n", path2string(event.Path))
+		auditLog := newAuditLog(event)
+		auditLog.Info()
 	}
+}
+
+func newAuditLog(event auditLog) log.RestrictedFileAccessLog {
+	auditEvent := log.AuditEventLog{
+		Action:     "BLOCK", // TODO
+		Hostname:   nodename2string(event.Nodename),
+		PID:        event.PID,
+		Comm:       comm2string(event.Command),
+		ParentComm: comm2string(event.ParentCommand),
+	}
+
+	fileAccessLog := log.RestrictedFileAccessLog{
+		AuditEventLog: auditEvent,
+		Path:          path2string(event.Path),
+	}
+
+	return fileAccessLog
 }
 
 func parseEvent(eventBytes []byte) (auditLog, error) {

--- a/pkg/commands/fileaccess/audit_test.go
+++ b/pkg/commands/fileaccess/audit_test.go
@@ -20,6 +20,7 @@ func TestAudit_DenyAccess(t *testing.T) {
 	done := make(chan bool)
 	conf := config.DefaultConfig()
 	conf.RestrictedFileAccess.Mode = "block"
+	conf.RestrictedFileAccess.Target = "host"
 	conf.RestrictedFileAccess.Deny = []string{be_blocked_path}
 	eventsChannel := make(chan []byte)
 	auditManager := runAuditWithOnce(conf, []string{"cat", be_blocked_path}, eventsChannel)
@@ -82,7 +83,7 @@ func TestAudit_Container(t *testing.T) {
 
 			if be_blocked_path == path2string(event.Path) {
 				assert.Equal(t, int32(-1), event.Ret)
-				assert.NotEqual(t, len(nodename2string(event.Nodename)), hostname)
+				assert.NotEqual(t, nodename2string(event.Nodename), hostname)
 				assert.Equal(t, be_blocked_path, path2string(event.Path))
 				done <- true
 				break

--- a/pkg/commands/fileaccess/audit_test.go
+++ b/pkg/commands/fileaccess/audit_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package fileaccess
 
 import (
@@ -14,6 +17,7 @@ func TestAudit_DenyAccess(t *testing.T) {
 	timeout := time.After(10 * time.Second)
 	done := make(chan bool)
 	conf := config.DefaultConfig()
+	conf.RestrictedFileAccess.Mode = "block"
 	conf.RestrictedFileAccess.Deny = []string{be_blocked_path}
 	eventsChannel := make(chan []byte)
 	auditManager := runAuditWithOnce(conf, []string{"cat", be_blocked_path}, eventsChannel)
@@ -26,6 +30,7 @@ func TestAudit_DenyAccess(t *testing.T) {
 			assert.Nil(t, err)
 
 			if be_blocked_path == path2string(event.Path) {
+				assert.Equal(t, int32(-1), event.Ret)
 				assert.Equal(t, auditManager.cmd.Process.Pid, int(event.PID))
 				assert.Equal(t, be_blocked_path, path2string(event.Path))
 				done <- true

--- a/pkg/commands/fileaccess/audit_test.go
+++ b/pkg/commands/fileaccess/audit_test.go
@@ -1,0 +1,72 @@
+package fileaccess
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/mrtc0/bouheki/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAudit_DenyAccess(t *testing.T) {
+	be_blocked_path := "/etc/hosts"
+	timeout := time.After(10 * time.Second)
+	done := make(chan bool)
+	conf := config.DefaultConfig()
+	conf.RestrictedFileAccess.Deny = []string{be_blocked_path}
+	eventsChannel := make(chan []byte)
+	auditManager := runAuditWithOnce(conf, []string{"cat", be_blocked_path}, eventsChannel)
+
+	go func() {
+		for {
+			eventBytes := <-eventsChannel
+
+			event, err := parseEvent(eventBytes)
+			assert.Nil(t, err)
+
+			if be_blocked_path == path2string(event.Path) {
+				assert.Equal(t, auditManager.cmd.Process.Pid, int(event.PID))
+				assert.Equal(t, be_blocked_path, path2string(event.Path))
+				done <- true
+				break
+			}
+		}
+	}()
+
+	select {
+	case <-timeout:
+		t.Fatalf("Timeout. %s has not accessed.", be_blocked_path)
+	case <-done:
+		t.Log("OK")
+	}
+
+	err := exec.Command("cat", "/etc/passwd").Run()
+	assert.Nil(t, err)
+}
+
+type TestAuditManager struct {
+	manager Manager
+	cmd     *exec.Cmd
+}
+
+func runAuditWithOnce(conf *config.Config, execCmd []string, eventsChannel chan []byte) TestAuditManager {
+	mgr := createManager(conf)
+	mgr.Attach()
+	mgr.Start(eventsChannel)
+
+	cmd := exec.Command(execCmd[0], execCmd[1:]...)
+	err := cmd.Start()
+
+	if err != nil {
+		panic(err)
+	}
+
+	cmd.Wait()
+
+	return TestAuditManager{
+		manager: mgr,
+		cmd:     cmd,
+	}
+
+}

--- a/pkg/commands/fileaccess/manager.go
+++ b/pkg/commands/fileaccess/manager.go
@@ -13,6 +13,9 @@ const (
 	FILEACCESS_CONFIG = "fileopen_bouheki_config"
 	MODE_MONITOR      = uint32(0)
 	MODE_BLOCK        = uint32(1)
+
+	TARGET_HOST      = uint32(0)
+	TARGET_CONTAINER = uint32(1)
 )
 
 type Manager struct {
@@ -53,7 +56,7 @@ func (m *Manager) Attach() error {
 }
 
 func (m *Manager) SetConfigToMap() error {
-	err := m.setMode()
+	err := m.setModeAndTarget()
 	if err != nil {
 		return err
 	}
@@ -88,8 +91,8 @@ func (m *Manager) SetConfigToMap() error {
 	return nil
 }
 
-func (m *Manager) setMode() error {
-	key := make([]byte, 4)
+func (m *Manager) setModeAndTarget() error {
+	key := make([]byte, 8)
 	configMap, err := m.mod.GetMap(FILEACCESS_CONFIG)
 	if err != nil {
 		return err
@@ -99,6 +102,12 @@ func (m *Manager) setMode() error {
 		binary.LittleEndian.PutUint32(key[0:4], MODE_BLOCK)
 	} else {
 		binary.LittleEndian.PutUint32(key[0:4], MODE_MONITOR)
+	}
+
+	if m.config.IsFileAccessOnlyContainer() {
+		binary.LittleEndian.PutUint32(key[4:8], TARGET_CONTAINER)
+	} else {
+		binary.LittleEndian.PutUint32(key[4:8], TARGET_HOST)
 	}
 
 	err = configMap.Update(uint8(0), key)

--- a/pkg/commands/fileaccess/manager.go
+++ b/pkg/commands/fileaccess/manager.go
@@ -1,0 +1,77 @@
+package fileaccess
+
+import (
+	"fmt"
+
+	"github.com/aquasecurity/libbpfgo"
+	"github.com/mrtc0/bouheki/pkg/config"
+	log "github.com/mrtc0/bouheki/pkg/log"
+)
+
+type Manager struct {
+	mod    *libbpfgo.Module
+	config *config.Config
+	pb     *libbpfgo.PerfBuffer
+}
+
+func (m *Manager) Start(eventChannel chan []byte) error {
+	pb, err := m.mod.InitPerfBuf("fileopen_events", eventChannel, nil, 1024)
+	if err != nil {
+		return err
+	}
+
+	pb.Start()
+	m.pb = pb
+
+	return nil
+}
+
+func (m *Manager) Close() {
+	m.pb.Close()
+}
+
+func (m *Manager) Attach() error {
+	prog, err := m.mod.GetProgram(BPF_PROGRAM_NAME)
+	if err != nil {
+		return err
+	}
+
+	_, err = prog.AttachLSM()
+	if err != nil {
+		return err
+	}
+
+	log.Debug(fmt.Sprintf("%s attached.", BPF_PROGRAM_NAME))
+	return nil
+}
+
+func (m *Manager) SetConfigToMap() error {
+	map_allowed_files, err := m.mod.GetMap(ALLOWED_FILES_MAP_NAME)
+	if err != nil {
+		return err
+	}
+	map_denied_files, err := m.mod.GetMap(DENIED_FILES_MAP_NAME)
+	if err != nil {
+		return err
+	}
+
+	allowed_paths := m.config.RestrictedFileAccess.Allow
+
+	for i, path := range allowed_paths {
+		err = map_allowed_files.Update(uint8(i), []byte(path))
+		if err != nil {
+			return err
+		}
+	}
+
+	denied_paths := m.config.RestrictedFileAccess.Deny
+
+	for i, path := range denied_paths {
+		err = map_denied_files.Update(uint8(i), []byte(path))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/commands/fileaccess/manager_test.go
+++ b/pkg/commands/fileaccess/manager_test.go
@@ -1,0 +1,129 @@
+package fileaccess
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/mrtc0/bouheki/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Start(t *testing.T) {
+	t.Run("expect to be initialize perf buffer", func(t *testing.T) {
+		config := config.DefaultConfig()
+		mgr := createManager(config)
+
+		eventChannel := make(chan []byte)
+		actual := mgr.Start(eventChannel)
+		assert.Equal(t, nil, actual)
+	})
+}
+
+func Test_Attach(t *testing.T) {
+	t.Run("expect to be attach BPF Program", func(t *testing.T) {
+		config := config.DefaultConfig()
+		mgr := createManager(config)
+
+		actual := mgr.Attach()
+		assert.Equal(t, nil, actual)
+	})
+}
+
+func Test_SetConfigMap_AllowedFiles(t *testing.T) {
+	tests := []struct {
+		name         string
+		allowedFiles []string
+		deniedFiles  []string
+		expected     []byte
+	}{
+		{
+			name:         "test",
+			allowedFiles: []string{"/"},
+			deniedFiles:  []string{"/etc/passwd"},
+			expected:     []byte{0x2f},
+		},
+	}
+
+	config := config.DefaultConfig()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config.RestrictedFileAccess.Allow = test.allowedFiles
+			config.RestrictedFileAccess.Deny = test.deniedFiles
+			mgr := createManager(config)
+
+			err := mgr.SetConfigToMap()
+			assert.Equal(t, nil, err)
+
+			map_allowed_files, err := mgr.mod.GetMap(ALLOWED_FILES_MAP_NAME)
+			if err != nil {
+				t.Fatalf("Failed open eBPF map for %s, err: %s", ALLOWED_FILES_MAP_NAME, err)
+			}
+
+			actual, err := map_allowed_files.GetValue(uint8(0), PATH_MAX)
+			if err != nil {
+				t.Fatalf("Faild to get value from eBPF map %s, err: %s", ALLOWED_FILES_MAP_NAME, err)
+			}
+
+			padding := bytes.Repeat([]byte{0x00}, PATH_MAX-len(test.allowedFiles))
+			expected := append(test.expected, padding...)
+			assert.Equal(t, expected, actual)
+		})
+	}
+}
+
+func Test_SetConfigMap_DeniedFiles(t *testing.T) {
+	tests := []struct {
+		name         string
+		allowedFiles []string
+		deniedFiles  []string
+		expected     []byte
+	}{
+		{
+			name:         "test",
+			allowedFiles: []string{"/"},
+			deniedFiles:  []string{"/etc/passwd"},
+			expected:     []byte{0x2f, 0x65, 0x74, 0x63, 0x2f, 0x70, 0x61, 0x73, 0x73, 0x77, 0x64},
+		},
+	}
+
+	config := config.DefaultConfig()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config.RestrictedFileAccess.Allow = test.allowedFiles
+			config.RestrictedFileAccess.Deny = test.deniedFiles
+			mgr := createManager(config)
+
+			err := mgr.SetConfigToMap()
+			assert.Equal(t, nil, err)
+
+			map_denied_files, err := mgr.mod.GetMap(DENIED_FILES_MAP_NAME)
+			if err != nil {
+				t.Fatalf("Failed open eBPF map for %s, err: %s", DENIED_FILES_MAP_NAME, err)
+			}
+
+			actual, err := map_denied_files.GetValue(uint8(0), PATH_MAX)
+			if err != nil {
+				t.Fatalf("Faild to get value from eBPF map %s, err: %s", DENIED_FILES_MAP_NAME, err)
+			}
+
+			padding := bytes.Repeat([]byte{0x00}, PATH_MAX-len(test.expected))
+			expected := append(test.expected, padding...)
+
+			assert.Equal(t, expected, actual)
+		})
+	}
+}
+
+func createManager(conf *config.Config) Manager {
+	mod, err := setupBPFProgram()
+	if err != nil {
+		panic(err)
+	}
+
+	mgr := Manager{
+		mod:    mod,
+		config: conf,
+	}
+
+	return mgr
+}

--- a/pkg/commands/fileaccess/manager_test.go
+++ b/pkg/commands/fileaccess/manager_test.go
@@ -125,5 +125,10 @@ func createManager(conf *config.Config) Manager {
 		config: conf,
 	}
 
+	err = mgr.SetConfigToMap()
+	if err != nil {
+		panic(err)
+	}
+
 	return mgr
 }

--- a/pkg/commands/network/audit.go
+++ b/pkg/commands/network/audit.go
@@ -154,15 +154,18 @@ func RunAudit(conf *config.Config) {
 			log.Error(err)
 		}
 
-		auditLog := NewAuditLog(header, body)
+		auditLog := newAuditLog(header, body)
 		auditLog.Info()
 	}
 }
 
-func NewAuditLog(header eventHeader, body detectEvent) log.RestrictedNetworkLog {
-	var addr string
-	var port uint16
-	var socktype uint8
+func newAuditLog(header eventHeader, body detectEvent) log.RestrictedNetworkLog {
+	var (
+		addr     string
+		port     uint16
+		socktype uint8
+	)
+
 	if header.EventType == BLOCKED_IPV6 {
 		body := body.(detectEventIPv6)
 		port = body.DstPort

--- a/pkg/commands/network/audit.go
+++ b/pkg/commands/network/audit.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mrtc0/bouheki/pkg/bpf"
 	"github.com/mrtc0/bouheki/pkg/config"
 	log "github.com/mrtc0/bouheki/pkg/log"
-	"github.com/sirupsen/logrus"
 
 	"github.com/aquasecurity/libbpfgo"
 )
@@ -155,32 +154,43 @@ func RunAudit(conf *config.Config) {
 			log.Error(err)
 		}
 
-		var addr string
-		var port uint16
-		var socktype uint8
-		if header.EventType == BLOCKED_IPV6 {
-			body := body.(detectEventIPv6)
-			port = body.DstPort
-			addr = byte2IPv6(body.DstIP)
-			socktype = body.SockType
-		} else {
-			body := body.(detectEventIPv4)
-			port = body.DstPort
-			addr = byte2IPv4(body.DstIP)
-			socktype = body.SockType
-		}
-
-		log.WithFields(logrus.Fields{
-			"Action":     body.ActionResult(),
-			"Hostname":   nodename2string(header.Nodename),
-			"PID":        header.PID,
-			"Comm":       comm2string(header.Command),
-			"ParentComm": comm2string(header.ParentCommand),
-			"Addr":       addr,
-			"Port":       port,
-			"Protocol":   sockTypeToProtocolName(socktype),
-		}).Info("Traffic is trapped in the filter.")
+		auditLog := NewAuditLog(header, body)
+		auditLog.Info()
 	}
+}
+
+func NewAuditLog(header eventHeader, body detectEvent) log.RestrictedNetworkLog {
+	var addr string
+	var port uint16
+	var socktype uint8
+	if header.EventType == BLOCKED_IPV6 {
+		body := body.(detectEventIPv6)
+		port = body.DstPort
+		addr = byte2IPv6(body.DstIP)
+		socktype = body.SockType
+	} else {
+		body := body.(detectEventIPv4)
+		port = body.DstPort
+		addr = byte2IPv4(body.DstIP)
+		socktype = body.SockType
+	}
+
+	auditEvent := log.AuditEventLog{
+		Action:     body.ActionResult(),
+		Hostname:   nodename2string(header.Nodename),
+		PID:        header.PID,
+		Comm:       comm2string(header.Command),
+		ParentComm: comm2string(header.ParentCommand),
+	}
+
+	networkLog := log.RestrictedNetworkLog{
+		AuditEventLog: auditEvent,
+		Addr:          addr,
+		Port:          port,
+		Protocol:      sockTypeToProtocolName(socktype),
+	}
+
+	return networkLog
 }
 
 func parseEvent(eventBytes []byte) (eventHeader, detectEvent, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,9 +17,10 @@ type NetworkConfig struct {
 }
 
 type RestrictedFileAccess struct {
-	Mode  string   `yaml:"mode"`
-	Allow []string `yaml:"allow"`
-	Deny  []string `yaml:"deny"`
+	Mode   string   `yaml:"mode"`
+	Target string   `yaml:"target"`
+	Allow  []string `yaml:"allow"`
+	Deny   []string `yaml:"deny"`
 }
 
 type DomainConfig struct {
@@ -73,9 +74,10 @@ func DefaultConfig() *Config {
 			GID:     GIDConfig{Allow: []uint{}, Deny: []uint{}},
 		},
 		RestrictedFileAccess: RestrictedFileAccess{
-			Mode:  "monitor",
-			Allow: []string{"/"},
-			Deny:  []string{},
+			Mode:   "monitor",
+			Target: "host",
+			Allow:  []string{"/"},
+			Deny:   []string{},
 		},
 		Log: LogConfig{
 			Format: "json",
@@ -121,6 +123,14 @@ func (c *Config) IsOnlyContainer() bool {
 
 func (c *Config) IsFileAccessBlock() bool {
 	if c.RestrictedFileAccess.Mode == "block" {
+		return true
+	} else {
+		return false
+	}
+}
+
+func (c *Config) IsFileAccessOnlyContainer() bool {
+	if c.RestrictedFileAccess.Target == "container" {
 		return true
 	} else {
 		return false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,11 @@ type NetworkConfig struct {
 	GID     GIDConfig     `yaml:"gid"`
 }
 
+type RestrictedFileAccess struct {
+	Allow []string `yaml:"allow"`
+	Deny  []string `yaml:"deny"`
+}
+
 type DomainConfig struct {
 	Allow    []string `yaml:"allow"`
 	Deny     []string `yaml:"deny"`
@@ -51,7 +56,8 @@ type LogConfig struct {
 
 type Config struct {
 	Network NetworkConfig
-	Log     LogConfig
+	RestrictedFileAccess
+	Log LogConfig
 }
 
 func DefaultConfig() *Config {
@@ -64,6 +70,10 @@ func DefaultConfig() *Config {
 			Domain:  DomainConfig{Allow: []string{}, Deny: []string{}, Interval: 5},
 			UID:     UIDConfig{Allow: []uint{}, Deny: []uint{}},
 			GID:     GIDConfig{Allow: []uint{}, Deny: []uint{}},
+		},
+		RestrictedFileAccess: RestrictedFileAccess{
+			Allow: []string{"/"},
+			Deny:  []string{},
 		},
 		Log: LogConfig{
 			Format: "json",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ type NetworkConfig struct {
 }
 
 type RestrictedFileAccess struct {
+	Mode  string   `yaml:"mode"`
 	Allow []string `yaml:"allow"`
 	Deny  []string `yaml:"deny"`
 }
@@ -72,6 +73,7 @@ func DefaultConfig() *Config {
 			GID:     GIDConfig{Allow: []uint{}, Deny: []uint{}},
 		},
 		RestrictedFileAccess: RestrictedFileAccess{
+			Mode:  "monitor",
 			Allow: []string{"/"},
 			Deny:  []string{},
 		},
@@ -99,6 +101,7 @@ func NewConfig(configPath string) (*Config, error) {
 	return config, nil
 }
 
+// TODO: rename
 func (c *Config) IsRestricted() bool {
 	if c.Network.Mode == "block" {
 		return true
@@ -107,8 +110,17 @@ func (c *Config) IsRestricted() bool {
 	}
 }
 
+// TODO: rename
 func (c *Config) IsOnlyContainer() bool {
 	if c.Network.Target == "container" {
+		return true
+	} else {
+		return false
+	}
+}
+
+func (c *Config) IsFileAccessBlock() bool {
+	if c.RestrictedFileAccess.Mode == "block" {
 		return true
 	} else {
 		return false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,9 +55,9 @@ type LogConfig struct {
 }
 
 type Config struct {
-	Network NetworkConfig
-	RestrictedFileAccess
-	Log LogConfig
+	Network              NetworkConfig
+	RestrictedFileAccess `yaml:"files"`
+	Log                  LogConfig
 }
 
 func DefaultConfig() *Config {

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -114,6 +114,17 @@ func (l *RestrictedNetworkLog) Info() {
 	}).Info("Traffic is trapped in the filter.")
 }
 
+func (l *RestrictedFileAccessLog) Info() {
+	log.WithFields(logrus.Fields{
+		"Action":     l.Action,
+		"Hostname":   l.Hostname,
+		"PID":        l.PID,
+		"Comm":       l.Comm,
+		"ParentComm": l.ParentComm,
+		"Path":       l.Path,
+	}).Info("File access is trapped in th filter.")
+}
+
 type RestrictedFileAccessLog struct {
 	AuditEventLog
 	Path string

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"os"
 
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
@@ -83,4 +84,37 @@ func Error(err error) {
 
 func WithFields(fields log.Fields) *log.Entry {
 	return log.WithFields(fields)
+}
+
+type AuditEventLog struct {
+	Action     string
+	Hostname   string
+	PID        uint32
+	Comm       string
+	ParentComm string
+}
+
+type RestrictedNetworkLog struct {
+	AuditEventLog
+	Addr     string
+	Port     uint16
+	Protocol string
+}
+
+func (l *RestrictedNetworkLog) Info() {
+	log.WithFields(logrus.Fields{
+		"Action":     l.Action,
+		"Hostname":   l.Hostname,
+		"PID":        l.PID,
+		"Comm":       l.Comm,
+		"ParentComm": l.ParentComm,
+		"Addr":       l.Addr,
+		"Port":       l.Port,
+		"Protocol":   l.Protocol,
+	}).Info("Traffic is trapped in the filter.")
+}
+
+type RestrictedFileAccessLog struct {
+	AuditEventLog
+	Path string
 }

--- a/testdata/fileaccess/allow_all.yml
+++ b/testdata/fileaccess/allow_all.yml
@@ -1,0 +1,15 @@
+network:
+  mode: block
+  target: host
+  cidr:
+    allow:
+      - 0.0.0.0/0
+files:
+  mode: block
+  allow:
+    - '/'
+  deny:
+    - '/etc/passwd'
+    - '/etc/test'
+log:
+  format: json

--- a/testdata/fileaccess/allow_all.yml
+++ b/testdata/fileaccess/allow_all.yml
@@ -6,6 +6,7 @@ network:
       - 0.0.0.0/0
 files:
   mode: block
+  target: container
   allow:
     - '/'
   deny:


### PR DESCRIPTION
File open can now be restricted by attaching lsm/open.

For example, Access to `/etc/passwd` and `/etc/test` can be disabled with the following configuration:

```yaml
network:
  mode: block
  target: host
  cidr:
    allow:
      - 0.0.0.0/0
files:
  mode: block
  target: container
  allow:
    - '/'
  deny:
    - '/etc/passwd'
    - '/etc/test'
log:
  format: json
```